### PR TITLE
Add interactive setup CLI

### DIFF
--- a/src/dev/build/tasks/copy_source_task.ts
+++ b/src/dev/build/tasks/copy_source_task.ts
@@ -26,7 +26,7 @@ export const CopySource: Task = {
         '!src/test_utils/**',
         '!src/fixtures/**',
         '!src/cli/repl/**',
-        '!src/cli/dev.js',
+        '!src/cli*/dev.js',
         '!src/functional_test_runner/**',
         '!src/dev/**',
         '!**/jest.config.js',


### PR DESCRIPTION
Modifies the globs used in the build scripts to ignore `dev.js` files inside of each `cli*` directory within source when creating the build. We previously excluded `cli/dev.js` but all those files can and should be excluded.